### PR TITLE
Create setup.py to enable module installation via pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+import sys
+
+with open('README.md') as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+        name="CobaltStrikeParser",
+        version="11721a49",
+        description="Python parser for CobaltStrike Beacon's configuration",
+        license="Attribution-NonCommercial-ShareAlike 4.0 International",
+        long_description=long_description,
+        url="https://github.com/Sentinel-One/CobaltStrikeParser",
+        py_modules=["parse_beacon_config", "beacon_utils"],
+        install_requires=["urllib3",
+            "requests",
+            "netstruct==1.1.2",
+            "pefile==2019.4.18"]
+        )


### PR DESCRIPTION
This is a minimal setup script to enable installation via pip. This makes it much easier to use the parse_beacon_config module as a dependency in a larger project. Rather than manually including this repo it can be listed as a requirement for example a requirements.txt entry would look like:

`git+https://github.com/Sentinel-One/CobaltStrikeParser.git@master` 

I tried to pick appropriate values for the fields but I was unsure what to choose for version, I'm fairly certain you don't want the commit hash there. 

Thanks for building this parser! It's incredibly useful. 